### PR TITLE
chore: kotlin and sdk upgrade

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,7 +26,7 @@ rootProject.allprojects {
 }
 
 android {
-    compileSdkVersion 35
+    compileSdkVersion 36
     namespace "com.resideo.flutter_audio_streaming"
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/src/main/kotlin/com/resideo/flutter_audio_streaming/DartMessenger.kt
+++ b/android/src/main/kotlin/com/resideo/flutter_audio_streaming/DartMessenger.kt
@@ -19,7 +19,7 @@ class DartMessenger(messenger: BinaryMessenger, id : String) {
             return
         }
         val event: MutableMap<String, String?> = HashMap()
-        event["eventType"] = eventType.toString().toLowerCase(Locale.ROOT)
+        event["eventType"] = eventType.toString().lowercase(Locale.ROOT)
         // Only errors have a description.
         if (!TextUtils.isEmpty(description)) {
             event["errorDescription"] = description

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    namespace "com.resideo.flutter_audio_streaming_example"
+    compileSdkVersion 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -36,7 +37,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.resideo.flutter_audio_streaming_example"
         minSdkVersion 26
-        targetSdkVersion 33
+        targetSdkVersion 36
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip


### PR DESCRIPTION
This pull request updates the Android build configuration for both the main library and the example app to use newer versions of Gradle, the Android Gradle plugin, and Kotlin. It also raises the compile and target SDK versions to 36, and makes a minor code modernization in the Kotlin source. These changes help keep the project up-to-date with the latest Android tooling and SDK requirements.

**Build system and dependency updates:**

* Upgraded Gradle wrapper versions to 8.0 in both the main library (`android/gradle/wrapper/gradle-wrapper.properties`) and the example app (`example/android/gradle/wrapper/gradle-wrapper.properties`). [[1]](diffhunk://#diff-4c5ffadbdf6016477a1c3768e0b7381cc298bd558b1784871f407cbcb0efacceL3-R3) [[2]](diffhunk://#diff-33c9d420f392affbc15e8f6d9c82c03f20fb6498eddce1843e70285f041c327dL6-R6)
* Updated the Android Gradle plugin to 8.1.4 and Kotlin to 1.9.10 in both `android/build.gradle` and `example/android/build.gradle`. [[1]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL2-R9) [[2]](diffhunk://#diff-ed8534ece8080a880075e103269eb1b9bdff22e8dfcf8427d7d977603292b889L2-R10)

**SDK version updates:**

* Increased `compileSdkVersion` to 36 in both the main library (`android/build.gradle`) and the example app (`example/android/app/build.gradle`). [[1]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL29-R29) [[2]](diffhunk://#diff-39ab2ed24002fb8e39b9db8ebac35907f77395dbc3c2faf95e6e6b6805e0b9ceL29-R30)
* Increased `targetSdkVersion` to 36 in the example app (`example/android/app/build.gradle`).

**Code modernization:**

* Replaced deprecated `toLowerCase(Locale.ROOT)` with `lowercase(Locale.ROOT)` in `DartMessenger.kt` for better Kotlin idiomatic usage.